### PR TITLE
Pulling email from upstream idp token if missing

### DIFF
--- a/openid_connect_azure_b2c.module
+++ b/openid_connect_azure_b2c.module
@@ -1,20 +1,7 @@
 <?php
 
-use Drupal\Component\Serialization\Json;
 use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
 use Drupal\openid_connect_azure_b2c\Plugin\OpenIDConnectClient\OpenIDConnectB2CClient;
-
-
-function parseToken(string $token) {
-  $parts = explode('.', $token, 3);
-  if (count($parts) === 3) {
-    $decoded = Json::decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $parts[1])));
-    if (is_array($decoded)) {
-      return $decoded;
-    }
-  }
-  return $token;
-}
 
 /**
  * Implements hook_openid_connect_userinfo_alter().
@@ -26,28 +13,7 @@ function openid_connect_azure_b2c_openid_connect_userinfo_alter(array &$userinfo
   if (!$plugin instanceof OpenIDConnectB2CClient) {
     return;
   }
-
-  // The email can be in multiple places, try and extract it from each in turn
-  $email = '';
-  if (array_key_exists('email', $userinfo)) {
-    // Prefer the email claim if present
-    $email = $userinfo['email'];
-  } elseif (array_key_exists('emails', $userinfo) && array_key_exists(0, $userinfo['emails'])) {
-    // If not, and there are alternate emails, use the first one
-    $email = $userinfo['emails'][0];
-  } elseif (array_key_exists('idp_access_token', $userinfo)) {
-
-    // If neither are present, but we have a proxied IdP token, extract data from that
-    $idp_userinfo = parseToken($userinfo['idp_access_token']);
-    if (array_key_exists('email', $idp_userinfo)) {
-      // Prefer email from the upstream token
-      $email = $idp_userinfo['email'];
-    } elseif (array_key_exists('upn', $idp_userinfo)) {
-      // but settle for the unique name
-      $email = $idp_userinfo['upn'];
-    }
-  }
-
-  $userinfo['email'] = $email;
+  
+  $userinfo['email'] = $plugin->extractEmail($userinfo);
 }
 

--- a/openid_connect_azure_b2c.module
+++ b/openid_connect_azure_b2c.module
@@ -1,7 +1,20 @@
 <?php
 
+use Drupal\Component\Serialization\Json;
 use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
 use Drupal\openid_connect_azure_b2c\Plugin\OpenIDConnectClient\OpenIDConnectB2CClient;
+
+
+function parseToken(string $token) {
+  $parts = explode('.', $token, 3);
+  if (count($parts) === 3) {
+    $decoded = Json::decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $parts[1])));
+    if (is_array($decoded)) {
+      return $decoded;
+    }
+  }
+  return $token;
+}
 
 /**
  * Implements hook_openid_connect_userinfo_alter().
@@ -14,7 +27,27 @@ function openid_connect_azure_b2c_openid_connect_userinfo_alter(array &$userinfo
     return;
   }
 
-  // Use the 0th email as the main one
-  $userinfo['email'] = $userinfo['emails'][0];
+  // The email can be in multiple places, try and extract it from each in turn
+  $email = '';
+  if (array_key_exists('email', $userinfo)) {
+    // Prefer the email claim if present
+    $email = $userinfo['email'];
+  } elseif (array_key_exists('emails', $userinfo) && array_key_exists(0, $userinfo['emails'])) {
+    // If not, and there are alternate emails, use the first one
+    $email = $userinfo['emails'][0];
+  } elseif (array_key_exists('idp_access_token', $userinfo)) {
+
+    // If neither are present, but we have a proxied IdP token, extract data from that
+    $idp_userinfo = parseToken($userinfo['idp_access_token']);
+    if (array_key_exists('email', $idp_userinfo)) {
+      // Prefer email from the upstream token
+      $email = $idp_userinfo['email'];
+    } elseif (array_key_exists('upn', $idp_userinfo)) {
+      // but settle for the unique name
+      $email = $idp_userinfo['upn'];
+    }
+  }
+
+  $userinfo['email'] = $email;
 }
 

--- a/src/Plugin/OpenIDConnectClient/OpenIDConnectB2CClient.php
+++ b/src/Plugin/OpenIDConnectClient/OpenIDConnectB2CClient.php
@@ -88,7 +88,10 @@ class OpenIDConnectB2CClient extends OpenIDConnectClientBase {
   }
 
   /**
-   * Parse the token from upstream.
+   * Extract the data from a JWT without validation.
+   *
+   * @param string $token
+   *   A JWT in its head.body.sig format.
    */
   protected static function parseToken(string $token): array {
     $parts = explode('.', $token, 3);
@@ -103,9 +106,13 @@ class OpenIDConnectB2CClient extends OpenIDConnectClientBase {
 
   /**
    * Extract the email from various options within the token.
+   *
+   * @param array $userinfo
+   *   The extracted token contents as passed to the openid_connect
+   *   userinfo alter hook.
    */
   public static function extractEmail(array $userinfo) : string {
-    // The email can be in multiple places, try and extract it from each in turn.
+    // The email can be in multiple places, try to extract it from each in turn.
     $email = '';
     if (array_key_exists('email', $userinfo)) {
       // Prefer the email claim if present.
@@ -116,7 +123,8 @@ class OpenIDConnectB2CClient extends OpenIDConnectClientBase {
       $email = $userinfo['emails'][0];
     }
     elseif (array_key_exists('idp_access_token', $userinfo)) {
-      // If neither are present, but we have a proxied IdP token, extract data from that.
+      // If neither are present, but we have a proxied IdP token, extract
+      // data from that.
       $idp_userinfo = OpenIDConnectB2CClient::parseToken($userinfo['idp_access_token']);
       if (array_key_exists('email', $idp_userinfo)) {
         // Prefer email from the upstream token.

--- a/src/Plugin/OpenIDConnectClient/OpenIDConnectB2CClient.php
+++ b/src/Plugin/OpenIDConnectClient/OpenIDConnectB2CClient.php
@@ -90,7 +90,7 @@ class OpenIDConnectB2CClient extends OpenIDConnectClientBase {
   /**
    * Parse the token from upstream.
    */
-  protected static function parseToken(string $token) {
+  protected static function parseToken(string $token): array {
     $parts = explode('.', $token, 3);
     if (count($parts) === 3) {
       $decoded = Json::decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $parts[1])));
@@ -98,7 +98,7 @@ class OpenIDConnectB2CClient extends OpenIDConnectClientBase {
         return $decoded;
       }
     }
-    return $token;
+    return [];
   }
 
   /**

--- a/src/Plugin/OpenIDConnectClient/OpenIDConnectB2CClient.php
+++ b/src/Plugin/OpenIDConnectClient/OpenIDConnectB2CClient.php
@@ -2,14 +2,14 @@
 
 namespace Drupal\openid_connect_azure_b2c\Plugin\OpenIDConnectClient;
 
-
+use Drupal\Component\Serialization\Json;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\openid_connect\Plugin\OpenIDConnectClientBase;
 
 /**
  * Azure B2C OpenID Connect client.
  *
- * Used to connect to Azure B2C
+ * Used to connect to Azure B2C.
  *
  * @OpenIDConnectClient(
  *   id = "b2c",
@@ -56,7 +56,6 @@ class OpenIDConnectB2CClient extends OpenIDConnectClientBase {
     return $form;
   }
 
-
   /**
    * {@inheritdoc}
    */
@@ -75,16 +74,60 @@ class OpenIDConnectB2CClient extends OpenIDConnectClientBase {
   public function getClientScopes(): ?array {
     return $this->configuration['scopes'];
   }
+
   /**
    * {@inheritdoc}
    */
   public function getEndpoints() : array {
     return [
-      'authorization' => 'https://' . $this->configuration['tenant'] . '.b2clogin.com/' . $this->configuration['tenant']. '.onmicrosoft.com/oauth2/v2.0/authorize?p=' . $this->configuration['flow'],
-      'token' => 'https://' . $this->configuration['tenant'] . '.b2clogin.com/' . $this->configuration['tenant']. '.onmicrosoft.com/oauth2/v2.0/token?p=' . $this->configuration['flow'],
+      'authorization' => 'https://' . $this->configuration['tenant'] . '.b2clogin.com/' . $this->configuration['tenant'] . '.onmicrosoft.com/oauth2/v2.0/authorize?p=' . $this->configuration['flow'],
+      'token' => 'https://' . $this->configuration['tenant'] . '.b2clogin.com/' . $this->configuration['tenant'] . '.onmicrosoft.com/oauth2/v2.0/token?p=' . $this->configuration['flow'],
       'userinfo' => '',
-      'end_session' => 'https://' . $this->configuration['tenant'] . '.b2clogin.com/' . $this->configuration['tenant']. '.onmicrosoft.com/oauth2/v2.0/logout?p=' . $this->configuration['flow'],
+      'end_session' => 'https://' . $this->configuration['tenant'] . '.b2clogin.com/' . $this->configuration['tenant'] . '.onmicrosoft.com/oauth2/v2.0/logout?p=' . $this->configuration['flow'],
     ];
+  }
+
+  /**
+   * Parse the token from upstream.
+   */
+  protected static function parseToken(string $token) {
+    $parts = explode('.', $token, 3);
+    if (count($parts) === 3) {
+      $decoded = Json::decode(base64_decode(str_replace(['-', '_'], ['+', '/'], $parts[1])));
+      if (is_array($decoded)) {
+        return $decoded;
+      }
+    }
+    return $token;
+  }
+
+  /**
+   * Extract the email from various options within the token.
+   */
+  public static function extractEmail(array $userinfo) : string {
+    // The email can be in multiple places, try and extract it from each in turn.
+    $email = '';
+    if (array_key_exists('email', $userinfo)) {
+      // Prefer the email claim if present.
+      $email = $userinfo['email'];
+    }
+    elseif (array_key_exists('emails', $userinfo) && array_key_exists(0, $userinfo['emails'])) {
+      // If not, and there are alternate emails, use the first one.
+      $email = $userinfo['emails'][0];
+    }
+    elseif (array_key_exists('idp_access_token', $userinfo)) {
+      // If neither are present, but we have a proxied IdP token, extract data from that.
+      $idp_userinfo = OpenIDConnectB2CClient::parseToken($userinfo['idp_access_token']);
+      if (array_key_exists('email', $idp_userinfo)) {
+        // Prefer email from the upstream token.
+        $email = $idp_userinfo['email'];
+      }
+      elseif (array_key_exists('upn', $idp_userinfo)) {
+        // But settle for the unique name.
+        $email = $idp_userinfo['upn'];
+      }
+    }
+    return $email;
   }
 
 }

--- a/tests/src/Unit/ExtractEmailTest.php
+++ b/tests/src/Unit/ExtractEmailTest.php
@@ -16,7 +16,7 @@ use Drupal\Tests\UnitTestCase;
 class ExtractEmailTest extends UnitTestCase {
 
   /**
-   * Test for the userPropertiesIgnore method.
+   * Extract the email from a basic email claim.
    */
   public function testExtractFromEmailClaim(): void {
     $input = [
@@ -27,7 +27,11 @@ class ExtractEmailTest extends UnitTestCase {
   }
 
   /**
+   * Extract email from the emails claim.
    *
+   * B2C can send an emails claim which consists of various
+   * emails known to the system. If it does this, use the
+   * first.
    */
   public function testExtractFromFirstInEmailsClaim(): void {
     $input = [
@@ -41,7 +45,11 @@ class ExtractEmailTest extends UnitTestCase {
   }
 
   /**
+   * Prefer the email claim to the emails claim.
    *
+   * If both email and emails are sent, prefer the singular
+   * email, as there's not actually any canonical ordering
+   * in the emails claim.
    */
   public function testPreferEmailToEmails(): void {
     $input = [
@@ -56,9 +64,14 @@ class ExtractEmailTest extends UnitTestCase {
   }
 
   /**
+   * Use email in the upstream token.
    *
+   * If we have neither email or emails, but we have the
+   * idp_access_token claim then use that. This claim contains
+   * a JWT that came from the IdP that was used by B2C to validate
+   * the login. Check for an email claim in that.
    */
-  public function testExtractFromEmailInUpstreamIdPToken(): void {
+  public function testExtractFromEmailInUpstreamIdpToken(): void {
     // Secret is 'a' - see jwt.io.
     $input = [
       "idp_access_token" => "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6InVwc3RyZWFtQGV4YW1wbGUuY29tIn0.m9LZdnfe9yhFmnNm5pXmQhR9pLNMXKCps-EFLq4WcPQ",
@@ -68,9 +81,12 @@ class ExtractEmailTest extends UnitTestCase {
   }
 
   /**
+   * Use upn in the upstream token.
    *
+   * Also consider a upn claim in that upstream token, which can
+   * often be an email.
    */
-  public function testExtractFromUPNInUpstreamIdPToken(): void {
+  public function testExtractFromUpnInUpstreamIdpToken(): void {
     // Secret is 'a' - see jwt.io.
     $input = [
       "idp_access_token" => "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ1cG4iOiJvdGhlckBleGFtcGxlLmNvbSJ9.zFUbWQ0axMOyT4nTpX14FYXW8mFh1t5gjtnhXOQq098",
@@ -80,7 +96,10 @@ class ExtractEmailTest extends UnitTestCase {
   }
 
   /**
+   * Return an empty string if no match.
    *
+   * If there are no matching claims to consider, return an
+   * empty string.
    */
   public function testMissingEmailDoesntError(): void {
     $input = [];
@@ -89,7 +108,10 @@ class ExtractEmailTest extends UnitTestCase {
   }
 
   /**
+   * Only use the emails claim if it's non-empty.
    *
+   * Finally, validate that the emails claim is only used
+   * if it contains at least one email.
    */
   public function testEmptyAlternativeEmailsDoesntPreventUsingIdP(): void {
     // Secret is 'a' - see jwt.io.

--- a/tests/src/Unit/ExtractEmailTest.php
+++ b/tests/src/Unit/ExtractEmailTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\openid_connect_azure_b2c\Unit;
+
+use Drupal\openid_connect_azure_b2c\Plugin\OpenIDConnectClient\OpenIDConnectB2CClient;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Provides tests for the OpenID Connect b2c email.
+ *
+ * @coversDefaultClass \Drupal\openid_connect_azure_b2c\Plugin\OpenIDConnectClient
+ * @group openid_connect_azure_b2c
+ */
+class ExtractEmailTest extends UnitTestCase {
+
+  /**
+   * Test for the userPropertiesIgnore method.
+   */
+  public function testExtractFromEmailClaim(): void {
+    $input = [
+      "email" => "foo@example.com",
+    ];
+    $email = OpenIDConnectB2CClient::extractEmail($input);
+    $this->assertEquals($email, "foo@example.com");
+  }
+
+  /**
+   *
+   */
+  public function testExtractFromFirstInEmailsClaim(): void {
+    $input = [
+      "emails" => [
+        "foo@example.com",
+        "bar@example.com",
+      ],
+    ];
+    $email = OpenIDConnectB2CClient::extractEmail($input);
+    $this->assertEquals($email, "foo@example.com");
+  }
+
+  /**
+   *
+   */
+  public function testPreferEmailToEmails(): void {
+    $input = [
+      "email" => "other@example.net",
+      "emails" => [
+        "foo@example.com",
+        "bar@example.com",
+      ],
+    ];
+    $email = OpenIDConnectB2CClient::extractEmail($input);
+    $this->assertEquals($email, "other@example.net");
+  }
+
+  /**
+   *
+   */
+  public function testExtractFromEmailInUpstreamIdPToken(): void {
+    // Secret is 'a' - see jwt.io.
+    $input = [
+      "idp_access_token" => "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6InVwc3RyZWFtQGV4YW1wbGUuY29tIn0.m9LZdnfe9yhFmnNm5pXmQhR9pLNMXKCps-EFLq4WcPQ",
+    ];
+    $email = OpenIDConnectB2CClient::extractEmail($input);
+    $this->assertEquals($email, "upstream@example.com");
+  }
+
+  /**
+   *
+   */
+  public function testExtractFromUPNInUpstreamIdPToken(): void {
+    // Secret is 'a' - see jwt.io.
+    $input = [
+      "idp_access_token" => "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ1cG4iOiJvdGhlckBleGFtcGxlLmNvbSJ9.zFUbWQ0axMOyT4nTpX14FYXW8mFh1t5gjtnhXOQq098",
+    ];
+    $email = OpenIDConnectB2CClient::extractEmail($input);
+    $this->assertEquals($email, "other@example.com");
+  }
+
+  /**
+   *
+   */
+  public function testMissingEmailDoesntError(): void {
+    $input = [];
+    $email = OpenIDConnectB2CClient::extractEmail($input);
+    $this->assertEquals($email, "");
+  }
+
+  /**
+   *
+   */
+  public function testEmptyAlternativeEmailsDoesntPreventUsingIdP(): void {
+    // Secret is 'a' - see jwt.io.
+    $input = [
+      "emails" => [],
+      "idp_access_token" => "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ1cG4iOiJvdGhlckBleGFtcGxlLmNvbSJ9.zFUbWQ0axMOyT4nTpX14FYXW8mFh1t5gjtnhXOQq098",
+    ];
+    $email = OpenIDConnectB2CClient::extractEmail($input);
+    $this->assertEquals($email, "other@example.com");
+  }
+
+}


### PR DESCRIPTION
This changes the way that the email address is determined to progressively look in different places:

1. The email claim
2. The first entry of the emails claim
3. The email claim of the upstream idp token
4. The upn claim of the upstream idp token

This change does not validate the signing of the upstream IdP's JWT as we do not have any credentials to do so. Those are kept in B2C. However, the claim as a whole is part of the signature from the B2C instance that we trust, so we transitively trust that it's valid as the B2C instance will have validated.